### PR TITLE
Normalize instances of the group name to “Puget Mesh”

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PugetMesh.org
 
-PugetMesh GitHub Pages.
+Puget Mesh GitHub Pages.
 
 Using Material for MKDocs and bootstrapped with mtnme.sh. Thank you.
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -4,7 +4,7 @@ status: new
 
 # About Us
 
-PugetMesh is a volunteer community group in the Puget Sound region of Washington State and Canada. We focus on supporting AREDN, Meshtastic, and other mesh networks in our area. 
+Puget Mesh is a volunteer community group in the Puget Sound region of Washington State and Canada. We focus on supporting AREDN, Meshtastic, and other mesh networks in our area. 
 
 ### Follow us on:
 - [Discord](https://discord.gg/ANvUg3AyZt)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Welcome
 
 [![Puget Mesh Logo](/static/PugetMeshLogo_200.png){ align=left }](/static/PugetMeshLogo.svg)
-Welcome to PugetMesh.org. We are a volunteer community group that supports AREDN, Meshtastic, and other Mesh networks in the Puget Sound Region.
+Puget Mesh is a volunteer community group that supports AREDN, Meshtastic, and other Mesh networks in the Puget Sound Region.
 
 We love chatting on and off of the mesh. We use Discord for nearly all of our communication outside of the mesh. It is also a great place to get help, share pictures, and get ideas for projects. All other inquiries can be sent to inquiry@pugetmesh.org.
 

--- a/docs/meshtastic/config.md
+++ b/docs/meshtastic/config.md
@@ -114,7 +114,7 @@ __Approximate Location:__ Choose a value you are comfortable with.
 
 ---
 
-## Add the PugetMesh Channel
+## Add the Puget Mesh Channel
 Use [this link](https://meshtastic.org/e/?add=true#CiESEIx68aUDqunRAQuS3a91C60aCFBTLU1lc2ghJQIAAAASDwgBOAFABUgBUB5oAcgGAQ) or QR code to add the channel - be sure to pay attention when adding the channel so you don't replace your current channels.
 
 ![PS-Mesh! QR Code](/media/ps-mesh-qr.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Puget Mesh
-site_author: PugetMesh.org
-site_description: "PugetMesh: Supporting Mesh networks in the Puget Sound Region"
+site_author: Puget Mesh
+site_description: "Puget Mesh: Supporting Mesh networks in the Puget Sound Region"
 copyright: © Creative Commons Attribution-ShareAlike 4.0 International License
 site_url: https://pugetmesh.org
 repo_url: https://github.com/pugetmesh/pugetmesh.github.io


### PR DESCRIPTION
I found the inconsistent variations of the name to be confusing and wasn’t sure how I should refer to the group.